### PR TITLE
Add dockerfile for container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+output
+output.tar
+Dockerfile
+readme.md

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /system/**/_temp
 /temp/
 system/os_platform/win32_sdl/_build/
+
+output
+output.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM gcc:7.3
+
+
+RUN apt-get update \
+    && apt-get -y install git  bzr lib32z1 lib32ncurses5 nodejs vim
+
+RUN ln -s `which nodejs` /usr/bin/node
+
+WORKDIR /home/dev
+
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 \
+    && tar xvf gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 \
+    && rm gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
+
+
+ENV PATH $PATH:/home/dev/gcc-arm-none-eabi-7-2018-q2-update/bin
+
+
+COPY . .
+
+RUN ./build.sh
+
+CMD [bash]
+
+
+
+
+
+
+

--- a/build.sh
+++ b/build.sh
@@ -3,11 +3,11 @@
 set -x
 mkdir output
 
-cd ./system/os_host
+cd ./system/os_library
+./build.sh
+cd ../os_host
 ./build.sh
 cp ./build/system_la104.hex ../../output/
-cd ../os_library
-./build.sh 
 cd ../../tools/elfstrip
 ./build.sh
 cd ../../system/apps_shell/test29_fileman 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+mkdir output
+
+cd ./system/os_host
+./build.sh
+cp ./build/system_la104.hex ../../output/
+cd ../os_library
+./build.sh 
+cd ../../tools/elfstrip
+./build.sh
+cd ../../system/apps_shell/test29_fileman 
+./build.sh
+cp ./build/29fileman_la104.elf ../../../output/shell.elf
+

--- a/readme.md
+++ b/readme.md
@@ -273,3 +273,19 @@ Connect your midi keyboard with two wires (3V and P1 through 100-330 ohm resisto
   - direction control pins of buffer 1DIR, 2DIR connected to FPGA, so we can synthesize fast signals - e.g. modify packets on the fly, mitm attacks, canbus slave device, etc///
   - larger eeprom
   - open sourced FPGA code
+
+# Docker
+The la104 images can be build using docker
+
+The Dockerfile builds a container which runs build.sh.
+build.sh executes the steps in the tutorial in the order presented.
+build image using the dockerfile with the following commands.
+
+```bash
+docker build . -t la104
+id=$(docker run -d --rm la104 sleep 300)
+docker cp $id:/home/dev/output - > ./output.tar
+tar -xvf output.tar
+docker rm -v $id
+```
+

--- a/resources/experiments/blink/buildmac.sh
+++ b/resources/experiments/blink/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/dynamic_advanced/client/build.sh
+++ b/resources/experiments/dynamic_advanced/client/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/dynamic_advanced/host/buildmac.sh
+++ b/resources/experiments/dynamic_advanced/host/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/dynamic_advanced/library/build.sh
+++ b/resources/experiments/dynamic_advanced/library/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/dynamic_simple/build.sh
+++ b/resources/experiments/dynamic_simple/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/dynamic_simple/secondary/buildmac.sh
+++ b/resources/experiments/dynamic_simple/secondary/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/triangle_cpp/buildmac.sh
+++ b/resources/experiments/triangle_cpp/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/triangle_newlib/buildmac.sh
+++ b/resources/experiments/triangle_newlib/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/triangle_oldlib/buildmac.sh
+++ b/resources/experiments/triangle_oldlib/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/experiments/worm/buildmac.sh
+++ b/resources/experiments/worm/buildmac.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/official_fw_gcc/buildmac.sh
+++ b/resources/official_fw_gcc/buildmac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/resources/tutorial_building/readme.md
+++ b/resources/tutorial_building/readme.md
@@ -16,7 +16,7 @@ https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 - Clone whole repository (git clone https://github.com/gabonator/LA104.git)
 - Building the OS: 
     - From the [/system/os_host](/system/os_host) folder, run **build_la104.sh** or **build_ds203.sh** or **build_ds213.sh**
-    - You will need to change the path to your arm toolchain by changing this line or by exporing the arm toolchain path: `````` 
+    - You will need to export the arm toolchain path: ```export PATH="~/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"``` 
     - Check the output of the script, it should look like this
         ```~/Documents/git/LA104/system/os_host$ ./build_la104.sh 
         20000000 00000000 D _addressRamBegin

--- a/resources/tutorial_building/readme.md
+++ b/resources/tutorial_building/readme.md
@@ -16,7 +16,7 @@ https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 - Clone whole repository (git clone https://github.com/gabonator/LA104.git)
 - Building the OS: 
     - From the [/system/os_host](/system/os_host) folder, run **build_la104.sh** or **build_ds203.sh** or **build_ds213.sh**
-    - You will need to change the path to your arm toolchain by changing this line or by exporing the arm toolchain path: ```export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"``` 
+    - You will need to change the path to your arm toolchain by changing this line or by exporing the arm toolchain path: `````` 
     - Check the output of the script, it should look like this
         ```~/Documents/git/LA104/system/os_host$ ./build_la104.sh 
         20000000 00000000 D _addressRamBegin
@@ -102,7 +102,7 @@ https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
     - Build it by running **build.sh** script, it will compile the code, link it with dummy library, and then remove unnecessary parts from the .elf file. Again you will need to fix the toolchain path:
     ```
-    export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+    
     mkdir -p build
     cd build
 

--- a/system/apps/test13_mp3/build.sh
+++ b/system/apps/test13_mp3/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps/test15_charmap/build.sh
+++ b/system/apps/test15_charmap/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test17_official/build.sh
+++ b/system/apps/test17_official/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test22_sequencer/build.sh
+++ b/system/apps/test22_sequencer/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test23_screenshot/build.sh
+++ b/system/apps/test23_screenshot/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test30_dcf77/build.sh
+++ b/system/apps/test30_dcf77/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps/test31_testsignal/build.sh
+++ b/system/apps/test31_testsignal/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test34_scope/build.sh
+++ b/system/apps/test34_scope/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test35_view/build.sh
+++ b/system/apps/test35_view/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test36_esp_server/build.sh
+++ b/system/apps/test36_esp_server/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test37_i2cscan/build.sh
+++ b/system/apps/test37_i2cscan/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test41_alchemy/build.sh
+++ b/system/apps/test41_alchemy/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test45_simcom/build.sh
+++ b/system/apps/test45_simcom/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test4_snake/build.sh
+++ b/system/apps/test4_snake/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test70_webusb/build.sh
+++ b/system/apps/test70_webusb/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps/test7_pwm_app/build.sh
+++ b/system/apps/test7_pwm_app/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_arduino/test11_i2c_api/build.sh
+++ b/system/apps_arduino/test11_i2c_api/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_arduino/test14_apds9960/build.sh
+++ b/system/apps_arduino/test14_apds9960/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_arduino/test18_onewire/build.sh
+++ b/system/apps_arduino/test18_onewire/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_ds213/52_oscilloscope/build.sh
+++ b/system/apps_ds213/52_oscilloscope/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/53_oscfpgatest/build.sh
+++ b/system/apps_ds213/53_oscfpgatest/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/54_gaboscshell/build.sh
+++ b/system/apps_ds213/54_gaboscshell/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/55_gabosc/build.sh
+++ b/system/apps_ds213/55_gabosc/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/58_gabmini/build.sh
+++ b/system/apps_ds213/58_gabmini/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/59_memtest/build.sh
+++ b/system/apps_ds213/59_memtest/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/60_gabgen/build.sh
+++ b/system/apps_ds213/60_gabgen/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/61_devinfo/build.sh
+++ b/system/apps_ds213/61_devinfo/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/62_memview/build.sh
+++ b/system/apps_ds213/62_memview/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_ds213/71_dmastreamer/build.sh
+++ b/system/apps_ds213/71_dmastreamer/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/72_uartmon/build.sh
+++ b/system/apps_experiments/72_uartmon/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/73_invt/build.sh
+++ b/system/apps_experiments/73_invt/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/75_invtemu/build.sh
+++ b/system/apps_experiments/75_invtemu/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/76_cc1101send/build.sh
+++ b/system/apps_experiments/76_cc1101send/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/77_dmatest/build.sh
+++ b/system/apps_experiments/77_dmatest/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/78_uartgen/build.sh
+++ b/system/apps_experiments/78_uartgen/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/79_cc1101osc/build_la104.sh
+++ b/system/apps_experiments/79_cc1101osc/build_la104.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/81_image/build.sh
+++ b/system/apps_experiments/81_image/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test10_i2c_direct/build.sh
+++ b/system/apps_experiments/test10_i2c_direct/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_experiments/test12_uart_api/build.sh
+++ b/system/apps_experiments/test12_uart_api/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_experiments/test16_cc1101/build.sh
+++ b/system/apps_experiments/test16_cc1101/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test1_noimport/build.sh
+++ b/system/apps_experiments/test1_noimport/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test20_uartplay/build.sh
+++ b/system/apps_experiments/test20_uartplay/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test27_irsend/build.sh
+++ b/system/apps_experiments/test27_irsend/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_experiments/test2_import/build.sh
+++ b/system/apps_experiments/test2_import/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test32_graph/build.sh
+++ b/system/apps_experiments/test32_graph/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test38_cc1101/build.sh
+++ b/system/apps_experiments/test38_cc1101/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test39_lcd/build.sh
+++ b/system/apps_experiments/test39_lcd/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test3_gui/build.sh
+++ b/system/apps_experiments/test3_gui/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test40_fpga/build.sh
+++ b/system/apps_experiments/test40_fpga/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test42_ccview/build.sh
+++ b/system/apps_experiments/test42_ccview/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test43_dumpmem/build.sh
+++ b/system/apps_experiments/test43_dumpmem/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test44_hardfault/build.sh
+++ b/system/apps_experiments/test44_hardfault/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test46_console/build.sh
+++ b/system/apps_experiments/test46_console/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test48_scroll/build.sh
+++ b/system/apps_experiments/test48_scroll/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test56_ds1307/build.sh
+++ b/system/apps_experiments/test56_ds1307/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_experiments/test57_ds3231/build.sh
+++ b/system/apps_experiments/test57_ds3231/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_experiments/test5_blink_hex/build.sh
+++ b/system/apps_experiments/test5_blink_hex/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test68_webusb/build.sh
+++ b/system/apps_experiments/test68_webusb/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test68_webusb/build_ds203.sh
+++ b/system/apps_experiments/test68_webusb/build_ds203.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test6_pwm_hex/build.sh
+++ b/system/apps_experiments/test6_pwm_hex/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test8_ds_app/build.sh
+++ b/system/apps_experiments/test8_ds_app/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_experiments/test9_dht_app/build.sh
+++ b/system/apps_experiments/test9_dht_app/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/69_webusbosc/build_ds203.sh
+++ b/system/apps_featured/69_webusbosc/build_ds203.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/69_webusbosc/build_ds213.sh
+++ b/system/apps_featured/69_webusbosc/build_ds213.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/69_webusbosc/build_la104.sh
+++ b/system/apps_featured/69_webusbosc/build_la104.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/74_invtvisual/build.sh
+++ b/system/apps_featured/74_invtvisual/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/80_rftool/build_la104.sh
+++ b/system/apps_featured/80_rftool/build_la104.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test21_midiplay/build_ds203.sh
+++ b/system/apps_featured/test21_midiplay/build_ds203.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test21_midiplay/build_la104.sh
+++ b/system/apps_featured/test21_midiplay/build_la104.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test33_temper/build.sh
+++ b/system/apps_featured/test33_temper/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test49_gpio/build.sh
+++ b/system/apps_featured/test49_gpio/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test63_ws2812/build_ds203.sh
+++ b/system/apps_featured/test63_ws2812/build_ds203.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test63_ws2812/build_ds213.sh
+++ b/system/apps_featured/test63_ws2812/build_ds213.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_featured/test63_ws2812/build_la104.sh
+++ b/system/apps_featured/test63_ws2812/build_la104.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_shell/test28_shell/build.sh
+++ b/system/apps_shell/test28_shell/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_shell/test29_fileman/build.sh
+++ b/system/apps_shell/test29_fileman/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 rm output.elf

--- a/system/apps_usb/test24_usbcdc/build.sh
+++ b/system/apps_usb/test24_usbcdc/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test25_hid/build.sh
+++ b/system/apps_usb/test25_hid/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test26_midi/build.sh
+++ b/system/apps_usb/test26_midi/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test32_sump/build.sh
+++ b/system/apps_usb/test32_sump/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test64_remote/build.sh
+++ b/system/apps_usb/test64_remote/build.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test67_webusb/1_build_.sh
+++ b/system/apps_usb/test67_webusb/1_build_.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test67_webusb/2_build_full_clean.sh
+++ b/system/apps_usb/test67_webusb/2_build_full_clean.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test67_webusb/3_build_single.sh
+++ b/system/apps_usb/test67_webusb/3_build_single.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test67_webusb/4_build_single_full.sh
+++ b/system/apps_usb/test67_webusb/4_build_single_full.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test67_webusb/5_build_single2.sh
+++ b/system/apps_usb/test67_webusb/5_build_single2.sh
@@ -1,6 +1,6 @@
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/apps_usb/test67_webusb/joiner/build_opencm3.sh
+++ b/system/apps_usb/test67_webusb/joiner/build_opencm3.sh
@@ -1,3 +1,3 @@
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 
 arm-none-eabi-gcc -Os -fno-common -mcpu=cortex-m3 -mthumb -msoft-float -fno-exceptions -DSTM32F1 -DLA104 -MD -D _ARM -D STM32F10X_HD -c opencm3.c

--- a/system/apps_usb/test67_webusb/joiner/build_webusb.sh
+++ b/system/apps_usb/test67_webusb/joiner/build_webusb.sh
@@ -1,3 +1,3 @@
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 
 arm-none-eabi-gcc -Os -fno-common -mcpu=cortex-m3 -mthumb -msoft-float -fno-exceptions -DSTM32F1 -DLA104 -MD -D _ARM -D STM32F10X_HD -c webusb.c

--- a/system/os_host/build_ds203.sh
+++ b/system/os_host/build_ds203.sh
@@ -3,7 +3,7 @@
 GITREVISION=`git log --pretty=format:'%h' -n 1`
 TARGET=DS203
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/os_host/build_ds213.sh
+++ b/system/os_host/build_ds213.sh
@@ -3,7 +3,7 @@
 GITREVISION=`git log --pretty=format:'%h' -n 1`
 TARGET=DS213
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/os_host/build_la104.sh
+++ b/system/os_host/build_la104.sh
@@ -3,7 +3,7 @@
 GITREVISION=`git log --pretty=format:'%h' -n 1`
 TARGET=LA104
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/os_host/build_la104_nousb.sh
+++ b/system/os_host/build_la104_nousb.sh
@@ -3,7 +3,7 @@
 GITREVISION=`git log --pretty=format:'%h' -n 1`
 TARGET=LA104
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/system/os_library/build.sh
+++ b/system/os_library/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 mkdir -p build
 cd build
 

--- a/tools/fpga/convert_hex_bin.sh
+++ b/tools/fpga/convert_hex_bin.sh
@@ -1,2 +1,2 @@
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 arm-none-eabi-objcopy --input-target=ihex --output-target=binary ds213v20.hex ds213v20.bin

--- a/tools/fpga/fpgahex.sh
+++ b/tools/fpga/fpgahex.sh
@@ -1,2 +1,2 @@
-export PATH="/Users/gabrielvalky/Downloads/gcc-arm-none-eabi-7-2018-q2-update/bin/":"$PATH"
+
 arm-none-eabi-objcopy --input-target=binary --output-target=ihex --change-addresses 0x08070000 ds213_v20_fpga ds213v20_fpga.hex 


### PR DESCRIPTION
Add the ability to build the [tutorial](resources/tutorial_building) using docker
The Dockerfile builds a container which runs build.sh.
The build files can then be extracted using `docker cp`
see [readme](./readme.md#docker)


@gabonator I would appreciate some help building some of the apps within this container :) 