### PR TITLE
Fix miniosc

### DIFF
--- a/system/apps_ds213/58_gabmini/source/Framework/ListItems.h
+++ b/system/apps_ds213/58_gabmini/source/Framework/ListItems.h
@@ -14,9 +14,10 @@ public:
 		m_Max = max;
 	}
 
-	virtual VPNavigate operator +(si8 d)
+	virtual VPNavigate operator +(int d)
 	{
 		return ( *m_pVal + d >= 0 && *m_pVal + d <= m_Max ) ? Yes : No; 
+		//return (*m_pVal == m_Max) ? No : Yes;
 	}
 
 	virtual void operator++(int)
@@ -67,7 +68,7 @@ public:
 		m_nMax = _max;
 	}
 
-	virtual VPNavigate operator +(si8 d)
+	virtual VPNavigate operator +(int d)
 	{
 		si16 n = (*m_pVal) + d;
 		return ( n >= m_nMin && n <= m_nMax ) ? Yes : No; 
@@ -125,7 +126,7 @@ public:
 		m_nMax = _max;
 	}
 
-	virtual VPNavigate operator +(si8 d)
+	virtual VPNavigate operator +(int d)
 	{
 		T n = (*m_pVal) + d;
 		return ( n >= m_nMin && n <= m_nMax ) ? Yes : No; 
@@ -169,7 +170,7 @@ public:
 		m_pVal = pColor;
 	}
 
-	virtual VPNavigate operator +(si8 d)
+	virtual VPNavigate operator +(int d)
 	{
 		return Disabled; 
 	}
@@ -202,7 +203,7 @@ public:
 		m_pName = pName;
 	}
 
-	virtual VPNavigate operator +(si8 d)
+	virtual VPNavigate operator +(int d)
 	{
 		return Disabled;
 	}
@@ -280,7 +281,7 @@ public:
 		_ASSERT(0);
 	}
 
-	virtual VPNavigate operator +(si8 d)
+	virtual VPNavigate operator +(int d)
 	{
 		if (d > 0 && GetValue() < 15)
 			return Yes;

--- a/system/apps_ds213/58_gabmini/source/Oscilloscope/Controls/GraphOsc.cpp
+++ b/system/apps_ds213/58_gabmini/source/Oscilloscope/Controls/GraphOsc.cpp
@@ -224,6 +224,24 @@ void CWndOscGraph::OnPaintTY()
 	ui8 en2 = Settings.CH2.Enabled == CSettings::AnalogChannel::_YES;
 	ui8 en3 = Settings.CH3.Enabled == CSettings::DigitalChannel::_YES;
 	ui8 en4 = Settings.CH4.Enabled == CSettings::DigitalChannel::_YES;
+	ui16 clrSource = RGB565(ff00ff);
+	switch ( Settings.Trig.Source )
+	{
+		case CSettings::Trigger::_CH1: 
+			clrSource = Settings.CH1.u16Color; 
+			break;
+		case CSettings::Trigger::_CH2: 
+			clrSource = Settings.CH2.u16Color; 
+			break;
+		case CSettings::Trigger::_CH3: 
+			clrSource = Settings.CH3.u16Color; 
+			break;
+		case CSettings::Trigger::_CH4: 
+			clrSource = Settings.CH4.u16Color; 
+			break;
+		case CSettings::Trigger::_Math: 
+			_ASSERT(0);
+	}
 
 	ui16 clrShade1 = 0, clrShade2 = 0, clrShade12 = 0;
 
@@ -455,7 +473,7 @@ void CWndOscGraph::OnPaintTY()
 		if ( bTrigger && (x & 1) == 1 )
 		{
 			ui16 y = (Settings.Trig.nLevel*(DivsY*BlkY))>>8;
-			column[y] = RGB565(404040);
+			column[y] = clrSource;
 		}
 		if ( nMarkerY1 > 0 )
 			column[nMarkerY1] = Settings.MarkY1.u16Color;

--- a/system/apps_ds213/58_gabmini/source/Oscilloscope/Controls/LevelRef.h
+++ b/system/apps_ds213/58_gabmini/source/Oscilloscope/Controls/LevelRef.h
@@ -9,6 +9,25 @@ public:
 
 	virtual void OnPaint()
 	{
+		ui16 clrSource = RGB565(ff00ff);
+
+		switch ( Settings.Trig.Source )
+		{
+			case CSettings::Trigger::_CH1: 
+				clrSource = Settings.CH1.u16Color; 
+				break;
+			case CSettings::Trigger::_CH2: 
+				clrSource = Settings.CH2.u16Color; 
+				break;
+			case CSettings::Trigger::_CH3: 
+				clrSource = Settings.CH3.u16Color; 
+				break;
+			case CSettings::Trigger::_CH4: 
+				clrSource = Settings.CH4.u16Color; 
+				break;
+			case CSettings::Trigger::_Math: 
+				_ASSERT(0);
+		}
 		//BIOS::LCD::Bar( m_rcClient, RGB565(000000) );
 		GUI::Background(m_rcClient, RGB565(101010), RGB565(404040));
 		//if ( Settings.Trig.Sync != CSettings::Trigger::_None )                                           
@@ -16,7 +35,7 @@ public:
 			ui16 y = Settings.Trig.nLevel;
 			y = (y * (CWndGraph::DivsY*CWndGraph::BlkY)) >> 8;
 			BIOS::LCD::Draw( m_rcClient.left, m_rcClient.bottom - y-5, 
-				RGB565(606060), RGBTRANS, CShapes::trig_base );
+				clrSource, RGBTRANS, CShapes::trig_base );
 		}
 		if ( Settings.CH2.Enabled )
 		{

--- a/system/apps_ds213/58_gabmini/source/Oscilloscope/Disp/ItemDisp.h
+++ b/system/apps_ds213/58_gabmini/source/Oscilloscope/Disp/ItemDisp.h
@@ -39,8 +39,8 @@ public:
 
 	virtual void OnKey(int nKey) override
 	{
-		if ( nKey == BIOS::KEY::Left && (*m_pProvider)-1 == CValueProvider::Yes )
-		{
+		if ( nKey == BIOS::KEY::Left && (*m_pProvider).Get() != 0 )
+		{			
 			(*m_pProvider)--;
 			Invalidate();
 			SendMessage(m_pParent, ToWord('u', 'p'), 0);

--- a/system/apps_ds213/58_gabmini/source/Oscilloscope/Input/ItemTime.h
+++ b/system/apps_ds213/58_gabmini/source/Oscilloscope/Input/ItemTime.h
@@ -18,9 +18,9 @@ public:
 	}
 
 	virtual void OnPaint() override
-	{
+	{			
 		ui16 clr = RGB565(000000);
-
+	
 		CWndMenuItem::OnPaint();
 		int x = m_rcClient.left + 12 + MarginLeft;
 		int y = m_rcClient.top;
@@ -40,8 +40,8 @@ public:
 
 	virtual void OnKey(int nKey) override
 	{
-		if ( nKey == BIOS::KEY::Left && m_proResolution-1 == CValueProvider::Yes )
-		{
+		if ( nKey == BIOS::KEY::Left && m_proResolution.Get() > 0)
+		{						
 			m_proResolution--;
 			Invalidate();
 			SendMessage(m_pParent, ToWord('i', 'u'), (ui32)(NATIVEPTR)m_pInfo);
@@ -54,10 +54,12 @@ public:
 		}
 		if ( nKey == BIOS::KEY::Enter )
 		{
+			Invalidate();
 			SendMessage(m_pParent, ToWord('m', 't'), (ui32)(NATIVEPTR)&m_proResolution);
 		}
 		CWnd::OnKey( nKey );
 	}
+
 };
 
 #endif

--- a/system/apps_ds213/58_gabmini/source/Oscilloscope/Input/ItemTrigger.h
+++ b/system/apps_ds213/58_gabmini/source/Oscilloscope/Input/ItemTrigger.h
@@ -111,7 +111,7 @@ public:
 
 	virtual void OnKey(int nKey) override
 	{
-		if ( nKey == BIOS::KEY::Left && m_proLevel-1 == CValueProvider::Yes )
+		if ( nKey == BIOS::KEY::Left && m_proLevel.Get() > 0)
 		{
 			m_proLevel--;
 			SendMessage(m_pParent, ToWord('r', 'u'), 0);
@@ -125,7 +125,37 @@ public:
 		{
 			SendMessage(m_pParent, ToWord('m', 'r'), 0);
 		}
-
+		if( nKey == BIOS::KEY::F3 )
+		{
+			ui16 clrSource = RGB565(ff00ff);
+			switch( Settings.Trig.Source )
+			{
+				case CSettings::Trigger::_CH1:
+					Settings.Trig.Source = CSettings::Trigger::_CH2;
+					clrSource = Settings.CH2.u16Color; 
+					break;
+				case CSettings::Trigger::_CH2:
+					Settings.Trig.Source = CSettings::Trigger::_CH3;
+					clrSource = Settings.CH3.u16Color; 
+					break;
+				case CSettings::Trigger::_CH3:
+					Settings.Trig.Source = CSettings::Trigger::_CH4;
+					clrSource = Settings.CH4.u16Color; 
+					break;
+				case CSettings::Trigger::_CH4:
+					Settings.Trig.Source = CSettings::Trigger::_CH1;
+					clrSource = Settings.CH1.u16Color; 
+					break;
+				default:
+					break;
+			}
+			ui16 y = Settings.Trig.nLevel;
+			y = (y * (CWndGraph::DivsY*CWndGraph::BlkY)) >> 8;
+			BIOS::LCD::Draw( 0, m_rcClient.bottom - y-2, 
+				clrSource, RGBTRANS, CShapes::trig_base );
+			SendMessage(m_pParent, ToWord('r', 'u'), 0);
+			CWnd::Invalidate();
+		}
 		CWnd::OnKey( nKey );
 	}
 

--- a/system/apps_ds213/58_gabmini/source/Oscilloscope/Input/MenuInput.cpp
+++ b/system/apps_ds213/58_gabmini/source/Oscilloscope/Input/MenuInput.cpp
@@ -92,6 +92,7 @@ CWndMenuInput::CWndMenuInput()
 	{
 		MainWnd.m_wndTReferences.Invalidate();
 		MainWnd.m_wndZoomBar.Invalidate();
+		MainWnd.m_wndGraph.Invalidate();
 		// if the osccilloscope window is freezed, inform to redraw it
 		if ( !BIOS::ADC::Enabled() )
 		{

--- a/system/apps_ds213/58_gabmini/source/app_ds213.lds
+++ b/system/apps_ds213/58_gabmini/source/app_ds213.lds
@@ -2,7 +2,7 @@ MEMORY
 {
   null (rwx): ORIGIN = 0x00001000, LENGTH = 4K
   rom (rx) : ORIGIN = 0x08013100, LENGTH = 40K
-  ram (rwx) : ORIGIN = 0x20002800, LENGTH = 28K
+  ram (rwx) : ORIGIN = 0x20002900, LENGTH = 28K
 }
 
 /*

--- a/system/apps_ds213/58_gabmini/source/main.cpp
+++ b/system/apps_ds213/58_gabmini/source/main.cpp
@@ -14,8 +14,12 @@ int _main(void)
     BIOS::KEY::EKey key;
     while (app.IsRunning())
     {
-	key = BIOS::KEY::GetKey();
-	
+	    key = BIOS::KEY::GetKey();
+        if (key==BIOS::KEY::F4)
+        {
+            CWnd::m_pTop->Invalidate();
+
+        }
         if (key != BIOS::KEY::None)
             app.WindowMessage(CWnd::WmKey, key);
 		


### PR DESCRIPTION
Fixed assertion failed warning
now the trigger line match the source channel color and you can change the source channel for the trigger by pressing F3 button