### PR TITLE
[gabuino] Feature/open external code

### DIFF
--- a/system/apps_featured/117_gabuino/web/v1/examples.js
+++ b/system/apps_featured/117_gabuino/web/v1/examples.js
@@ -1142,3 +1142,33 @@ examples =
     '    return 0;\n' +
     '}\n'
 }
+
+document.getElementById('input-file')
+      .addEventListener('change', getFile)
+
+    function getFile(event) {
+	    const input = event.target
+      if ('files' in input && input.files.length > 0) {
+	      placeFileContent(
+          html_editor,
+          input.files[0])
+
+          <!-- dirty hack for now just to remove the drop down menu -->
+          document.getElementById('_examples').setAttribute('class','dropdown-menu')
+      }
+    }
+
+    function placeFileContent(target, file) {
+	    readFileContent(file).then(content => {
+     	target.setValue(content)
+      }).catch(error => console.log(error))
+    }
+
+    function readFileContent(file) {
+	    const reader = new FileReader()
+      return new Promise((resolve, reject) => {
+        reader.onload = event => resolve(event.target.result)
+        reader.onerror = error => reject(error)
+        reader.readAsText(file)
+      })
+  }

--- a/system/apps_featured/117_gabuino/web/v1/examples.js
+++ b/system/apps_featured/117_gabuino/web/v1/examples.js
@@ -1148,7 +1148,7 @@ document.getElementById('input-file')
 
     function getFile(event) {
 	    const input = event.target
-      if ('files' in input && input.files.length > 0) {
+      if (input?.files.length) {
 	      placeFileContent(
           html_editor,
           input.files[0])

--- a/system/apps_featured/117_gabuino/web/v1/examples.js
+++ b/system/apps_featured/117_gabuino/web/v1/examples.js
@@ -1153,7 +1153,7 @@ document.getElementById('input-file')
           html_editor,
           input.files[0])
 
-          <!-- dirty hack for now just to remove the drop down menu -->
+          //dirty hack for now just to remove the drop down menu
           document.getElementById('_examples').setAttribute('class','dropdown-menu')
       }
     }

--- a/system/apps_featured/117_gabuino/web/v1/index.html
+++ b/system/apps_featured/117_gabuino/web/v1/index.html
@@ -53,6 +53,8 @@
           Examples
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown" id="_examples">
+          <label for="input-file">Specify a file:</label><br>
+          <input type="file" id="input-file">
         </div>
       </li>
 


### PR DESCRIPTION
# Issue
It's not much but I was limited by the hard-coded solution provided in https://github.com/gabonator/LA104/blob/master/system/apps_featured/117_gabuino/web/v1/examples.js#L1  

# Solution
So I've added a button under `Examples` that let you open external file.

## Note
I'm not the best in html so I'm not sure if there is a better way to hide the example drop down, if anyone want to adjust the solution your welcome :smile: .

