### PR TITLE
add missing cstdarhg

### DIFF
--- a/tools/elfdump/main.cpp
+++ b/tools/elfdump/main.cpp
@@ -7,7 +7,7 @@
 //
 
 #include <iostream>
-
+#include <cstdarg>
 
 #include "elf.h"
 #include "BufferedIo.h"


### PR DESCRIPTION
just added `cstdarg` on elfdump since I got error with the docker